### PR TITLE
Added support for a kettle variable for setting the path to the pytho…

### DIFF
--- a/src/org/pentaho/di/trans/steps/cpythonscriptexecutor/CPythonScriptExecutor.java
+++ b/src/org/pentaho/di/trans/steps/cpythonscriptexecutor/CPythonScriptExecutor.java
@@ -109,7 +109,7 @@ public class CPythonScriptExecutor extends BaseStep implements StepInterface {
         }
 
         // check python availability
-        CPythonScriptExecutorData.initPython();
+        CPythonScriptExecutorData.initPython(this, log);
       } catch ( KettleException ex ) {
         logError( ex.getMessage(), ex ); //$NON-NLS-1$
 
@@ -272,7 +272,7 @@ public class CPythonScriptExecutor extends BaseStep implements StepInterface {
                 .getString( PKG, "CPythonScriptExecutor.Message.PushingBatchIntoPandasDataFrame", //$NON-NLS-1$
                     frameBuffer.size(), frameName ) );
 
-            session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel() );
+            session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel(), this );
             rowsToPyDataFrame( session, m_data.m_incomingRowSets.get( i ).getRowMeta(), frameBuffer, frameName );
             framesAdded = true;
           } else {
@@ -289,7 +289,7 @@ public class CPythonScriptExecutor extends BaseStep implements StepInterface {
         }
       } else if ( !m_noInputRowSets && allDone ) {
         boolean framesAdded = false;
-        session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel() );
+        session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel(), this );
 
         // grab all the reservoirs an push to python; then process result
         logDetailed( BaseMessages.getString( PKG, "CPythonScriptExecutor.Message.RetrievingReservoirs" ) );
@@ -310,7 +310,7 @@ public class CPythonScriptExecutor extends BaseStep implements StepInterface {
               List<Object[]> sampleSpliced = new ArrayList<Object[]>();
               for ( int k = 0; k < sample.size(); k++ ) {
                 Object[] objects = sample.get( k );
-                session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel() );
+                session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel(), this );
                 sampleSpliced.clear();
                 sampleSpliced.add( objects );
                 rowsToPyDataFrame( session, m_data.m_incomingRowSets.get( j ).getRowMeta(), sampleSpliced, frameName );
@@ -334,7 +334,7 @@ public class CPythonScriptExecutor extends BaseStep implements StepInterface {
         }
       } else if ( m_noInputRowSets ) {
         // just get results from script as we have no inputs to us
-        session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel() );
+        session = CPythonScriptExecutorData.acquirePySession( this, getLogChannel(), this );
         executeScriptAndProcessResult( session, m_meta.getContinueOnUnsetVars() );
       }
     } finally {

--- a/src/org/pentaho/di/trans/steps/cpythonscriptexecutor/CPythonScriptExecutorData.java
+++ b/src/org/pentaho/di/trans/steps/cpythonscriptexecutor/CPythonScriptExecutorData.java
@@ -343,10 +343,9 @@ public class CPythonScriptExecutorData extends BaseStepData implements StepDataI
           } else {
             Object varVal = session.getVariableValueFromPythonAsPlainString( v );
             if ( m_outputRowMeta.getValueMeta( outputIndex ).getType() != ValueMetaInterface.TYPE_STRING ) {
-              varVal =
-                  m_outputRowMeta.getValueMeta( outputIndex )
-                      //.convertData( new ValueMeta( v, ValueMetaInterface.TYPE_STRING ), varVal );
-              .convertData(ValueMetaFactory.createValueMeta( v, ValueMetaInterface.TYPE_STRING ), varVal);
+              varVal = m_outputRowMeta.getValueMeta( outputIndex )
+                  //.convertData( new ValueMeta( v, ValueMetaInterface.TYPE_STRING ), varVal );
+                  .convertData( ValueMetaFactory.createValueMeta( v, ValueMetaInterface.TYPE_STRING ), varVal );
             }
             outputRow[outputIndex] = varVal;
           }
@@ -410,7 +409,9 @@ public class CPythonScriptExecutorData extends BaseStepData implements StepDataI
   protected static List<Object[]> generateRandomRows( RowMetaInterface inputMeta, Random r ) throws KettleException {
     List<Object[]> rows = new ArrayList<Object[]>( NUM_RANDOM_ROWS );
     // ValueMetaInterface numericVM = new ValueMeta( "num", ValueMetaInterface.TYPE_NUMBER ); //$NON-NLS-1$
-    ValueMetaInterface numericVM = ValueMetaFactory.createValueMeta( "num", ValueMetaInterface.TYPE_NUMBER ); //$NON-NLS-1$
+    ValueMetaInterface
+        numericVM =
+        ValueMetaFactory.createValueMeta( "num", ValueMetaInterface.TYPE_NUMBER ); //$NON-NLS-1$
 
     for ( int i = 0; i < NUM_RANDOM_ROWS; i++ ) {
       Object[] currentRow = new Object[inputMeta.size()];
@@ -501,7 +502,7 @@ public class CPythonScriptExecutorData extends BaseStepData implements StepDataI
 
         Random r = new Random( 1 );
 
-        session = acquirePySession( requester, log );
+        session = acquirePySession( requester, log, vars );
 
         List<List<Object[]>> randomRows = new ArrayList<List<Object[]>>();
         if ( inputMetas != null ) {
@@ -533,13 +534,11 @@ public class CPythonScriptExecutorData extends BaseStepData implements StepDataI
           return result;
         } else {
           // this variable is some other type
-          ValueMetaInterface
-              vm =
-              type == PythonSession.PythonVariableType.Image ?
-                  //new ValueMeta( varToGet, ValueMetaInterface.TYPE_SERIALIZABLE ) :
-                  ValueMetaFactory.createValueMeta( varToGet, ValueMetaInterface.TYPE_SERIALIZABLE ) :
-                  //new ValueMeta( varToGet, ValueMetaInterface.TYPE_STRING );
-                  ValueMetaFactory.createValueMeta( varToGet, ValueMetaInterface.TYPE_STRING );
+          ValueMetaInterface vm = type == PythonSession.PythonVariableType.Image ?
+              //new ValueMeta( varToGet, ValueMetaInterface.TYPE_SERIALIZABLE ) :
+              ValueMetaFactory.createValueMeta( varToGet, ValueMetaInterface.TYPE_SERIALIZABLE ) :
+              //new ValueMeta( varToGet, ValueMetaInterface.TYPE_STRING );
+              ValueMetaFactory.createValueMeta( varToGet, ValueMetaInterface.TYPE_STRING );
           PythonSession.RowMetaAndRows result = new PythonSession.RowMetaAndRows();
           result.m_rowMeta = new RowMeta();
           result.m_rowMeta.addValueMeta( vm );
@@ -553,11 +552,11 @@ public class CPythonScriptExecutorData extends BaseStepData implements StepDataI
     }
   }
 
-  public static void initPython() throws KettleException {
+  public static void initPython( VariableSpace vars, LogChannelInterface log ) throws KettleException {
     // check python availability
     if ( !PythonSession.pythonAvailable() ) {
       // initialize...
-      PythonSession.initSession( "python" );
+      PythonSession.initSession( "python", vars, log );
     } else {
       return;
     }
@@ -574,9 +573,10 @@ public class CPythonScriptExecutorData extends BaseStepData implements StepDataI
     }
   }
 
-  public static PythonSession acquirePySession( Object requester, LogChannelInterface log ) throws KettleException {
+  public static PythonSession acquirePySession( Object requester, LogChannelInterface log, VariableSpace vars )
+      throws KettleException {
     // check availability first...
-    initPython();
+    initPython( vars, log );
 
     PythonSession session;
     try {

--- a/src/org/pentaho/di/ui/trans/steps/cpythonscriptexecutor/CPythonScriptExecutorDialog.java
+++ b/src/org/pentaho/di/ui/trans/steps/cpythonscriptexecutor/CPythonScriptExecutorDialog.java
@@ -205,7 +205,7 @@ public class CPythonScriptExecutorDialog extends BaseStepDialog implements StepD
     addConfigureTab();
     addScriptTab();
     addFieldsTab();
-    checkPython();
+    // checkPython();
 
     fd = new FormData();
     fd.left = new FormAttachment( 0, 0 );
@@ -267,7 +267,7 @@ public class CPythonScriptExecutorDialog extends BaseStepDialog implements StepD
     if ( !PythonSession.pythonAvailable() ) {
       // try initializing
       try {
-        if ( !PythonSession.initSession( "python" ) ) {
+        if ( !PythonSession.initSession( "python", transMeta, log ) ) {
           String envEvalResults = PythonSession.getPythonEnvCheckResults();
           logError(
               "Was unable to start the python environment:\n\n" + ( envEvalResults != null ? envEvalResults : "" ) );


### PR DESCRIPTION
…n executable. This takes precedence over both the java property and the environment variable. Also plumbed some more logging through to PythonSession, so that logging output (at debugging level) can be seen for the python exe path and current state of the PATH variable. This can be useful for debugging when running in visual MR.