### PR TITLE
 Added additional check for the pyplot class

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -33,9 +33,9 @@ source.publish=false
 
 junit.maxmemory=500M
 
-dependency.kettle.revision=6.1-SNAPSHOT
-dependency.kettle5-log4j.revision=6.1-SNAPSHOT
-dependency.pentaho-metastore.revision=6.1-SNAPSHOT
+dependency.kettle.revision=6.1.0.0-184
+dependency.kettle5-log4j.revision=6.1.0.0-184
+dependency.pentaho-metastore.revision=6.1.0.0-184
 dependency.guava.revision=13.0.1
 dependency.commons-io.revision=1.3.2
 dependency.jackson-core.revision=1.9.13

--- a/resources/py/pyCheck.py
+++ b/resources/py/pyCheck.py
@@ -31,7 +31,15 @@ def check_libraries():
     check_library('pickle')
     check_library('scipy')
     check_library('sklearn')
-    check_library('matplotlib')
+    
+    if check_library('matplotlib'):
+        if not check_library('matplotlib', ['pyplot']):
+            print(
+                'It appears that the \'pyplot\' class in matplotlib ' +
+                'did not import correctly.\nIf you are using a Python ' +
+                'virtual environment please install the \'_tkinter\' module.' +
+                '\nPython must be installed as a framework for matplotlib ' +
+                'to work properly.')
 
     check_library('numpy')
     if check_library('pandas', ['DataFrame'], pandas_version_min):


### PR DESCRIPTION
For Python virtual environments, importing the pyplot class from matplotlib will fail. You need the _tkinter module. Previous pyCheck.py did not check for this and would not notify user of issue.

Also, the 6.1 SNAPSHOT dependency isn't there, so ant build fails. Needed to update that 6.1.0.0-184 to get this to build.